### PR TITLE
Feature/lottery and movie

### DIFF
--- a/src/exconfig.ts
+++ b/src/exconfig.ts
@@ -20,4 +20,12 @@ export default {
         'https://ethereum.org/static/6b935ac0e6194247347855dc3d328e83/6ed5f/eth-diamond-black.webp',
     },
   },
+  paymasterAddress: [ //paymasterコントラクトのアドレス
+    '0xBb1b4b23Fa7f4EE1Af8681F03fec91361987A54c',
+    '0x00000AB48215239dBE1bc1e7bFCC818EB426ad7B'//for test
+  ],
+  videoURL: [//paymasterに対応した広告動画URL
+    "https://player.vimeo.com/video/823615097?h=bd5248c7a2&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479",
+    "https://player.vimeo.com/video/437490927?h=26d7f84e5c"
+  ],
 };

--- a/src/pages/Popup/pages/sign-transaction-request/sign-transaction-request.tsx
+++ b/src/pages/Popup/pages/sign-transaction-request/sign-transaction-request.tsx
@@ -67,6 +67,7 @@ const SignTransactionConfirmation = ({
   const [paymasterError, setPaymasterError] = useState<string>('');
   const [paymasterAddress, setPaymasterAddress] = useState<string>('');
   const backgroundDispatch = useBackgroundDispatch();
+  const [showAdMovie, setShowAdMovie] = React.useState<boolean>(false);//広告動画表示の状態を管理
 
   const addPaymaster = useCallback(async () => {
     console.log(paymasterAddress);
@@ -235,14 +236,45 @@ const SignTransactionConfirmation = ({
             <Button
               sx={{ width: 150 }}
               variant="contained"
-              onClick={() => onSend()}
+              onClick={() => {
+                onSend();
+                setShowAdMovie(true);//Sendボタン押下と同時に広告表示
+              }}
             >
               Send
+              {showAdMovie && (
+                <CircularProgress
+                  size={24}
+                  sx={{
+                    position: 'absolute',
+                    top: '50%',
+                    left: '50%',
+                    marginTop: '-12px',
+                    marginLeft: '-12px',
+                  }}
+                />
+              )}
             </Button>
           </Box>
+
+          {showAdMovie && (
+            <Box sx={{ marginTop: 2 }}>
+              <iframe
+                width="280"
+                height="150"
+                src="https://www.youtube.com/embed/Jrz7RZJcfvU?autoplay=1"
+                title="YouTube video player"
+                frameborder="0"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                allowfullscreen
+              ></iframe>
+            </Box>
+          )}
+
         </Paper>
-      )}
-    </Container>
+      )
+      }
+    </Container >
   );
 };
 
@@ -284,7 +316,7 @@ const SignTransactionRequest = () => {
             context: _context || context,
           })
         );
-      window.close();
+      // window.close();
     },
     [activeAccount, backgroundDispatch, context]
   );

--- a/src/pages/Popup/pages/sign-transaction-request/sign-transaction-request.tsx
+++ b/src/pages/Popup/pages/sign-transaction-request/sign-transaction-request.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
 } from '@mui/material';
 import { BigNumber, ethers } from 'ethers';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import {
   AccountImplementations,
   ActiveAccountImplementation,
@@ -68,32 +68,31 @@ const SignTransactionConfirmation = ({
   const [paymasterAddress, setPaymasterAddress] = useState<string>('');
   const backgroundDispatch = useBackgroundDispatch();
   const [showAdMovie, setShowAdMovie] = React.useState<boolean>(false);//広告動画表示の状態を管理
+  const [paymasterIndex, setPaymasterIndex] = useState<number>(0);//Configで定義したpaymasterから取得するindexを格納
+  const [showText, setShowText] = useState(false); //動画を非表示にした後に表示する文字列の状態を管理
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout
+    if (showAdMovie) {
+      timer = setTimeout(() => {
+        setShowAdMovie(false);
+        setShowText(true);
+      }, 15000); //動画を表示したから一定時間経過後、文字列（くじの結果）を表示する。
+    }
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [showAdMovie]);
+
 
   const addPaymaster = useCallback(async () => {
-    console.log(paymasterAddress);
-    // setAddPaymasterLoader(true);
-    if (paymasterAddress) {
-      // const paymasterRPC = new ethers.providers.JsonRpcProvider(paymasterUrl, {
-      //   name: 'Paymaster',
-      //   chainId: parseInt(activeNetwork.chainID),
-      // });
-      // try {
-      //   const paymasterResp = await paymasterRPC.send(
-      //     'eth_getPaymasterAndDataSize',
-      //     [userOp]
-      //   );
-      //   backgroundDispatch(
-      //     setUnsignedUserOperation({
-      //       ...userOp,
-      //       paymasterAndData: paymasterResp,
-      //       verificationGasLimit: paymasterResp.verificationGasLimit,
-      //     })
-      //   );
-      // } catch (e) {
-      //   console.log(e);
-      //   setPaymasterError('Paymaster url returned error');
-      // }
-      const paymasterAndData = paymasterAddress; //paymasterコントラクトアドレスのみ格納
+    //1/2の確率で、PaymasterIndexに対応したPaymasterコントラクトアドレスを設定する。それ以外は、Paymasterなし
+    const lottery = Math.random();
+    console.log("lottery: ", lottery);
+    if (lottery <= 0.5) {
+      const paymasterAndData = Config.paymasterAddress[paymasterIndex]; //paymasterコントラクトアドレスのみ格納
+      setPaymasterAddress(paymasterAndData);
       console.log('paymasterAndData', paymasterAndData);
       backgroundDispatch(
         setUnsignedUserOperation({
@@ -103,9 +102,18 @@ const SignTransactionConfirmation = ({
           verificationGasLimit: 1000000,
         })
       );
-      // setAddPaymasterLoader(false);
+    } else {
+      setPaymasterAddress("");
+      console.log("No paymaster set");
     }
   }, [activeNetwork.chainID, backgroundDispatch, paymasterAddress, userOp]);
+
+  //広告動画のランダム選択のため、スポンサー数nを引数に取り、0,1...n-1のいずれかを取得。
+  const getRandomInt = (n: number) => {
+    const result: number = Math.floor(Math.random() * n);
+    console.log("PaymasterIndex: ", result);
+    setPaymasterIndex(result);
+  }
 
   return (
     <Container>
@@ -119,70 +127,6 @@ const SignTransactionConfirmation = ({
       )}
       <Stack spacing={2} sx={{ position: 'relative', pt: 2, mb: 4 }}>
         <OriginInfo permission={originPermission} />
-        <Typography variant="h6" sx-={{ p: 2 }}>
-          Paymaster Info
-        </Typography>
-        {!showAddPaymasterUI && (
-          <Paper sx={{ p: 2 }}>
-            <Typography variant="body2">
-              {userOp.paymasterAndData === '0x'
-                ? 'No paymaster has been used'
-                : 'paymaster has been set!'}
-            </Typography>
-            <Button onClick={() => setShowAddPaymasterUI(true)} variant="text">
-              Add custom
-            </Button>
-          </Paper>
-        )}
-        {showAddPaymasterUI && (
-          <Paper sx={{ p: 2 }}>
-            <TextField
-              value={paymasterAddress}
-              onChange={(e) => setPaymasterAddress(e.target.value)}
-              sx={{ width: '100%' }}
-              label="Paymaster Address"
-              variant="standard"
-            />
-            {paymasterError}
-            <Box
-              justifyContent="space-around"
-              alignItems="center"
-              display="flex"
-              sx={{ p: '16px 0px' }}
-            >
-              <Button
-                sx={{ width: 150 }}
-                variant="outlined"
-                onClick={() => {
-                  setShowAddPaymasterUI(false);
-                  setAddPaymasterLoader(false);
-                }}
-              >
-                Cancel
-              </Button>
-              <Button
-                disabled={addPaymasterLoader}
-                sx={{ width: 150, position: 'relative' }}
-                variant="contained"
-                onClick={addPaymaster}
-              >
-                Add
-                {addPaymasterLoader && (
-                  <CircularProgress
-                    size={24}
-                    sx={{
-                      position: 'absolute',
-                      top: '50%',
-                      left: '50%',
-                      marginTop: '-12px',
-                      marginLeft: '-12px',
-                    }}
-                  />
-                )}
-              </Button>
-            </Box>
-          </Paper>
-        )}
         <Typography variant="h6" sx-={{ p: 2 }}>
           {transactions.length > 1 ? ' Transactions data' : 'Transaction data'}
         </Typography>
@@ -237,8 +181,11 @@ const SignTransactionConfirmation = ({
               sx={{ width: 150 }}
               variant="contained"
               onClick={() => {
-                onSend();
+                // onSend();
+                getRandomInt((Config.paymasterAddress).length);//スポンサーをランダムに選択
+                addPaymaster();//選択したスポンサーをpaymasterに設定する or paymasterなし　を1/2の確率で選択
                 setShowAdMovie(true);//Sendボタン押下と同時に広告表示
+
               }}
             >
               Send
@@ -263,9 +210,20 @@ const SignTransactionConfirmation = ({
               display: 'flex',
               justifyContent: 'center'
             }}>
-              <iframe src="https://player.vimeo.com/video/823615097?h=bd5248c7a2&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479&amp;autoplay=1"
+              {/* paymasterに対応した動画URLをconfigから取得 */}
+              <iframe src={Config.videoURL[paymasterIndex] + "&autoplay=1&muted=1"}
                 width="280" height="150" frameborder="0" allow="autoplay; fullscreen; picture-in-picture"
-                allowfullscreen title="jhxjackypop_01"></iframe>
+                allowfullscreen ></iframe>
+            </Box>
+          )}
+          {!showAdMovie && showText && paymasterAddress && (
+            <Box sx={{ marginTop: 2, display: 'flex', justifyContent: 'center' }}>
+              <Typography variant="h6">当たり〜ガス代無料です！</Typography>
+            </Box>
+          )}
+          {!showAdMovie && showText && !paymasterAddress && (
+            <Box sx={{ marginTop: 2, display: 'flex', justifyContent: 'center' }}>
+              <Typography variant="h6">はずれ〜ガス代は自腹でね</Typography>
             </Box>
           )}
 

--- a/src/pages/Popup/pages/sign-transaction-request/sign-transaction-request.tsx
+++ b/src/pages/Popup/pages/sign-transaction-request/sign-transaction-request.tsx
@@ -244,7 +244,7 @@ const SignTransactionConfirmation = ({
               Send
               {showAdMovie && (
                 <CircularProgress
-                  size={24}
+                  size={48}
                   sx={{
                     position: 'absolute',
                     top: '50%',
@@ -258,16 +258,14 @@ const SignTransactionConfirmation = ({
           </Box>
 
           {showAdMovie && (
-            <Box sx={{ marginTop: 2 }}>
-              <iframe
-                width="280"
-                height="150"
-                src="https://www.youtube.com/embed/Jrz7RZJcfvU?autoplay=1"
-                title="YouTube video player"
-                frameborder="0"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                allowfullscreen
-              ></iframe>
+            <Box sx={{
+              marginTop: 2,
+              display: 'flex',
+              justifyContent: 'center'
+            }}>
+              <iframe src="https://player.vimeo.com/video/823615097?h=bd5248c7a2&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479&amp;autoplay=1"
+                width="280" height="150" frameborder="0" allow="autoplay; fullscreen; picture-in-picture"
+                allowfullscreen title="jhxjackypop_01"></iframe>
             </Box>
           )}
 


### PR DESCRIPTION
ポップアップダイアログ内のSENDボタンを押下したとき、以下の挙動となるようにしました。
・動画を再生。exconfig.tsで指定した動画の中から等確率で選択
・選択した動画に対応したPaymasterを、1/2の確率で指定（1/2の確率で、ユーザがガス代の自己負担）
・動画を再生した15秒後、ガス代負担元がどちらになったかの結果を文字列で表示

※UIのテストを繰り返すため、SENDボタンを押下しても実際のトランザクションは実行されないよう、
onSendイベントをコメントアウトしています。

※Paymasterのアドレスを直接入力で指定していた箇所は、不要のため削除